### PR TITLE
python 3.14 compatibility for asyncio

### DIFF
--- a/src/dump1090exporter/__main__.py
+++ b/src/dump1090exporter/__main__.py
@@ -117,7 +117,16 @@ def main():
     if args.latitude and args.longitude:
         args.origin = (args.latitude, args.longitude)
 
-    loop = asyncio.get_event_loop()
+    # Try to get the running event loop first, and if there isn't one, create a new one.
+    # This handles the Python 3.14+ behavior where get_event_loop() raises RuntimeError
+    # when there's no current event loop in the main thread
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        # No running event loop, create and set a new one
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
     mon = Dump1090Exporter(
         resource_path=args.resource_path,
         host=args.host,


### PR DESCRIPTION
without the fix you get:

```
2026-03-31T17:03:27.761105+02:00 ads-b dump1090exporter[214706]: Traceback (most recent call last):
2026-03-31T17:03:27.761670+02:00 ads-b dump1090exporter[214706]:   File "/home/markus/.local/bin/dump1090exporter", line 6, in <module>
2026-03-31T17:03:27.762162+02:00 ads-b dump1090exporter[214706]:     sys.exit(main())
2026-03-31T17:03:27.762577+02:00 ads-b dump1090exporter[214706]:              ~~~~^^
2026-03-31T17:03:27.762952+02:00 ads-b dump1090exporter[214706]:   File "/home/markus/.local/share/pipx/venvs/dump1090exporter/lib/python3.14/site-packages/dump1090exporter/__main__.py", line 120, in main
2026-03-31T17:03:27.763425+02:00 ads-b dump1090exporter[214706]:     loop = asyncio.get_event_loop()
2026-03-31T17:03:27.764040+02:00 ads-b dump1090exporter[214706]:   File "/usr/lib/python3.14/asyncio/events.py", line 715, in get_event_loop
2026-03-31T17:03:27.764524+02:00 ads-b dump1090exporter[214706]:     raise RuntimeError('There is no current event loop in thread %r.'
2026-03-31T17:03:27.765043+02:00 ads-b dump1090exporter[214706]:                        % threading.current_thread().name)
2026-03-31T17:03:27.765666+02:00 ads-b dump1090exporter[214706]: RuntimeError: There is no current event loop in thread 'MainThread'.
```

or

```
2026-03-31T17:06:26.143512+02:00 ads-b dump1090exporter[216053]: Traceback (most recent call last):
2026-03-31T17:06:26.144176+02:00 ads-b dump1090exporter[216053]:   File "/home/markus/.local/bin/dump1090exporter", line 6, in <module>
2026-03-31T17:06:26.144429+02:00 ads-b dump1090exporter[216053]:     sys.exit(main())
2026-03-31T17:06:26.144595+02:00 ads-b dump1090exporter[216053]:              ~~~~^^
2026-03-31T17:06:26.144849+02:00 ads-b dump1090exporter[216053]:   File "/home/markus/.local/share/pipx/venvs/dump1090exporter/lib/python3.14/site-packages/dump1090exporter/__main__.py", line 120, in main
2026-03-31T17:06:26.145186+02:00 ads-b dump1090exporter[216053]:     loop = asyncio.get_event_loop()
2026-03-31T17:06:26.145492+02:00 ads-b dump1090exporter[216053]:   File "/home/markus/.local/share/pipx/venvs/dump1090exporter/lib/python3.14/site-packages/uvloop/__init__.py", line 206, in get_event_loop
2026-03-31T17:06:26.145573+02:00 ads-b dump1090exporter[216053]:     raise RuntimeError(
2026-03-31T17:06:26.145652+02:00 ads-b dump1090exporter[216053]:     ...<2 lines>...
2026-03-31T17:06:26.145730+02:00 ads-b dump1090exporter[216053]:     )
2026-03-31T17:06:26.145879+02:00 ads-b dump1090exporter[216053]: RuntimeError: There is no current event loop in thread 'MainThread'.
```

inspired by https://github.com/python-telegram-bot/python-telegram-bot/pull/4875